### PR TITLE
Bump torch by a minor patch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-torch==1.13.0
+torch==1.13.1
 torchvision==0.14.0
 valohai-utils


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-47fc-vmwq-366v in the most minor way possible.